### PR TITLE
Update to eslint@2

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "eslint-config-vgno",
-  "version": "5.0.0",
+  "version": "6.0.0",
   "description": "ESLint configuration for VG.no coding standard",
   "main": "index.js",
   "scripts": {
@@ -25,11 +25,11 @@
   },
   "homepage": "https://github.com/vgno/eslint-config-vgno#readme",
   "dependencies": {
-    "lodash.merge": "^3.3.2",
-    "vgno-coding-standards": "^5.0.0"
+    "lodash.merge": "^4.3.4",
+    "vgno-coding-standards": "^6.0.0"
   },
   "devDependencies": {
-    "eslint": "^1.7.3"
+    "eslint": "^2.7.0"
   },
   "publishConfig": {
     "registry": "https://registry.npmjs.org/"

--- a/test/config.test.js
+++ b/test/config.test.js
@@ -19,4 +19,4 @@ assert.equal(reactConfig.rules.yoda, 2);
 // Ensure the React config specifies React rules, JSX and React plugin
 assert(reactConfig.rules['react/jsx-boolean-value'], 2);
 assert((reactConfig.plugins || []).indexOf('react') > -1);
-assert(reactConfig.ecmaFeatures.jsx);
+assert(reactConfig.parserOptions.ecmaFeatures.jsx);


### PR DESCRIPTION
This PR will:
- Update deps to vgno-coding-standards@6.0.0 - working with eslint@2.x.x
- Bump major version to 6
