### PR TITLE
Move to vgno-coding-standards 7.0 and eslint v3 and bump major

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -25,3 +25,4 @@ build/Release
 # Dependency directory
 # https://www.npmjs.org/doc/misc/npm-faq.html#should-i-check-my-node_modules-folder-into-git
 node_modules
+.idea/

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "eslint-config-vgno",
-  "version": "6.0.0",
+  "version": "7.0.0",
   "description": "ESLint configuration for VG.no coding standard",
   "main": "index.js",
   "scripts": {
@@ -25,11 +25,11 @@
   },
   "homepage": "https://github.com/vgno/eslint-config-vgno#readme",
   "dependencies": {
-    "lodash.merge": "^4.3.4",
-    "vgno-coding-standards": "^6.0.0"
+    "lodash.merge": "^4.5.1",
+    "vgno-coding-standards": "^7.0.0"
   },
   "devDependencies": {
-    "eslint": "^2.7.0"
+    "eslint": "^3.2.2"
   },
   "publishConfig": {
     "registry": "https://registry.npmjs.org/"


### PR DESCRIPTION
This is a sibling PR to: https://github.com/vgno/coding-standards/pull/46.

It will bump major to 7, use newest coding standards and bump major of eslint to v3 which is the newest one.
